### PR TITLE
Fix CardTitle forwardRef types

### DIFF
--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -30,7 +30,7 @@ const CardHeader = React.forwardRef<
 CardHeader.displayName = "CardHeader"
 
 const CardTitle = React.forwardRef<
-  HTMLParagraphElement,
+  HTMLHeadingElement,
   React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, ...props }, ref) => (
   <h3


### PR DESCRIPTION
## Summary
- Correct CardTitle's `forwardRef` generic types to use `HTMLHeadingElement`

## Testing
- `npm ci`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684a4f707ca08324a9b90a2ae61c8a32